### PR TITLE
refactor: simplify codebase by reducing over-engineering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
 
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Install dependencies
         run: uv sync --frozen
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pip install audiorag
 ### Optional Dependencies
 
 ```bash
-# Audio scraping utilities (yt-dlp, pydub)
+# Audio scraping utilities (yt-dlp, ffmpeg)
 uv add audiorag[defaults]  # or: pip install audiorag[defaults]
 
 # All providers and utilities

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ User Query
 |     Download      |---->|      Split        |---->|   Transcribe      |
 |                   |     |                   |     |                   |
 | - YouTube/audio   |     | - Large files     |     | - STT provider    |
-| - yt-dlp          |     | - pydub           |     | - Whisper/Deepgram|
+| - yt-dlp          |     | - ffmpeg          |     | - Whisper/Deepgram|
 +-------------------+     +-------------------+     +-------------------+
                                                                |
                                                                v
@@ -145,9 +145,9 @@ Pydantic-settings based configuration with environment variable support.
    - Supports concurrent fragments
    - Archive file for resumable scraping
 
-2. **Split**
+ 2. **Split**
    - Check file size against threshold
-   - Split large files using pydub
+   - Split large files using ffmpeg
    - Maintain sequential ordering
    - Track cumulative time offsets
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -22,7 +22,12 @@ Downloads audio from YouTube videos using yt-dlp with 2026 bleeding-edge extract
 
 **Installation:**
 ```bash
-uv add yt-dlp pydub
+# Requires ffmpeg to be installed on your system
+# On macOS: brew install ffmpeg
+# On Ubuntu/Debian: sudo apt install ffmpeg
+
+# YouTube extraction
+uv add yt-dlp
 # For YouTube 2026 JS challenge solving (mandatory since 2025.11.12)
 uv add yt-dlp-ejs curl-cffi
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,11 @@ audiorag = "audiorag.cli:main"
 [project.optional-dependencies]
 defaults = [
     "yt-dlp>=2026.02.04",
-    "pydub>=0.25",
 ]
 all = [
     "openai>=1.0",
     "chromadb>=0.4",
     "yt-dlp>=2026.02.04",
-    "pydub>=0.25",
     "cohere>=5.0",
     "pinecone-client>=2.0",
     "weaviate-client>=3.0",
@@ -89,7 +87,6 @@ rerank-cohere = ["cohere>=5.0"]
 # YouTube scraping
 youtube = [
     "yt-dlp>=2026.02.04",
-    "pydub>=0.25",
     "yt-dlp-ejs>=0.4.0",
     "curl_cffi>=0.7.0,<0.15.0",
 ]

--- a/src/audiorag/core/config.py
+++ b/src/audiorag/core/config.py
@@ -1,101 +1,61 @@
 """Configuration management for AudioRAG using pydantic-settings."""
 
+from __future__ import annotations
+
 import uuid
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+if TYPE_CHECKING:
+    from audiorag.core.config import AdvancedConfig
 
-class AudioRAGConfig(BaseSettings):
-    """AudioRAG configuration with environment variable support.
 
-    All settings use the AUDIORAG_ env prefix. Provider-specific model
-    defaults are handled by provider constructors, not this config.
+class AdvancedConfig(BaseSettings):
+    """Advanced configuration - rarely changed but available.
+
+    Access via config.advanced.* or AUDIORAG_ADVANCED_* env vars.
     """
 
-    model_config = SettingsConfigDict(
-        env_prefix="AUDIORAG_",
-        env_file=".env",
-        env_file_encoding="utf-8",
-        extra="ignore",
-    )
+    model_config = SettingsConfigDict(env_prefix="AUDIORAG_ADVANCED_", extra="ignore")
 
-    # -- Provider Selection --
-    stt_provider: str = "openai"
-    embedding_provider: str = "openai"
-    vector_store_provider: str = "chromadb"
-    generation_provider: str = "openai"
-    reranker_provider: str = "cohere"
-
-    # -- API Keys --
-    openai_api_key: str = ""
-    deepgram_api_key: str = ""
-    assemblyai_api_key: str = ""
-    groq_api_key: str = ""
-    voyage_api_key: str = ""
-    cohere_api_key: str = ""
-    anthropic_api_key: str = ""
-    google_api_key: str = ""
-    pinecone_api_key: str = ""
-    weaviate_url: str = ""
-    weaviate_api_key: str = ""
-    supabase_connection_string: str = ""
-    supabase_collection_name: str = "audiorag"
-    supabase_vector_dimension: int = 1536
-
-    # -- Vector Store Settings --
-    pinecone_index_name: str = "audiorag"
-    pinecone_namespace: str = "default"
-    weaviate_collection_name: str = "AudioRAG"
-    chromadb_persist_directory: str = "./chroma_db"
-    chromadb_collection_name: str = "audiorag"
-
-    # -- Database and Storage --
-    database_path: str = "audiorag.db"
-    work_dir: Path | None = None
-
-    # -- YouTube Scraping --
     youtube_download_archive: str | None = None
     youtube_concurrent_fragments: int = 3
     youtube_skip_after_errors: int = 3
     youtube_batch_size: int = 100
     youtube_max_concurrent: int = 3
     youtube_cookie_file: str | None = None
-    # Proof of Origin (PO) Token. Required for stable YouTube extraction since 2025.
     youtube_po_token: str | None = None
-    # Visitor Data and Data Sync ID. Often required to be bound to the PO Token.
     youtube_visitor_data: str | None = None
     youtube_data_sync_id: str | None = None
     youtube_impersonate: str | None = "chrome-120"
     youtube_player_clients: list[str] = ["tv", "web", "mweb"]
-    # Preferred JavaScript runtime for YouTube challenge solving. Deno is highly recommended.
     js_runtime: str | None = "deno"
 
-    # -- Audio Processing --
-    chunk_duration_seconds: int = 30
-    audio_format: str = "mp3"
-    audio_split_max_size_mb: int = 24
+    pinecone_index_name: str = "audiorag"
+    pinecone_namespace: str = "default"
+    weaviate_collection_name: str = "AudioRAG"
+    chromadb_persist_directory: str = "./chroma_db"
+    chromadb_collection_name: str = "audiorag"
+    supabase_collection_name: str = "audiorag"
+    supabase_vector_dimension: int = 1536
 
-    # -- Model Configuration --
     stt_model: str = "whisper-1"
     stt_language: str | None = None
     embedding_model: str = "text-embedding-3-small"
     generation_model: str = "gpt-4o-mini"
     reranker_model: str = "rerank-v3.5"
 
-    # -- Retrieval Settings --
     retrieval_top_k: int = 10
     rerank_top_n: int = 3
     cleanup_audio: bool = True
 
-    # -- Logging --
     log_level: str = "INFO"
     log_format: str = "colored"
     log_timestamps: bool = True
 
-    # -- Retry Configuration --
     retry_max_attempts: int = 3
     retry_min_wait_seconds: float = 4.0
     retry_max_wait_seconds: float = 60.0
@@ -116,14 +76,129 @@ class AudioRAGConfig(BaseSettings):
 
     @field_validator("vector_id_uuid5_namespace")
     @classmethod
-    def _validate_vector_id_uuid5_namespace(cls, value: str | None) -> str | None:
-        if value is None:
+    def _validate_uuid_ns(cls, v: str | None) -> str | None:
+        if v is None:
             return None
-        return str(uuid.UUID(value))
+        return str(uuid.UUID(v))
 
-    # -- Model Getter Methods (for backward compatibility) --
+
+_ADVANCED_KEYS: set[str] = set(AdvancedConfig.model_fields)
+
+
+class AudioRAGConfig(BaseSettings):
+    """AudioRAG main configuration.
+
+    Top-level settings (most common):
+    - Providers: stt, embedding, vector_store, generation, reranker
+    - API Keys: openai_api_key, deepgram_api_key, etc.
+    - Core: chunk_duration, audio_format, database_path, work_dir
+
+    Advanced settings via config.advanced.* or AUDIORAG_ADVANCED_* env vars.
+    Backward compatibility: old flat keys (e.g. config.stt_model) also work.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="AUDIORAG_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    stt_provider: str = "openai"
+    embedding_provider: str = "openai"
+    vector_store_provider: str = "chromadb"
+    generation_provider: str = "openai"
+    reranker_provider: str = "cohere"
+
+    openai_api_key: str = ""
+    deepgram_api_key: str = ""
+    assemblyai_api_key: str = ""
+    groq_api_key: str = ""
+    voyage_api_key: str = ""
+    cohere_api_key: str = ""
+    anthropic_api_key: str = ""
+    google_api_key: str = ""
+    pinecone_api_key: str = ""
+    weaviate_url: str = ""
+    weaviate_api_key: str = ""
+    supabase_connection_string: str = ""
+
+    chunk_duration_seconds: int = 30
+    audio_format: str = "mp3"
+    audio_split_max_size_mb: int = 24
+    database_path: str = "audiorag.db"
+    work_dir: Path | None = None
+
+    youtube_download_archive: str | None = None
+    youtube_concurrent_fragments: int = 3
+    youtube_skip_after_errors: int = 3
+    youtube_batch_size: int = 100
+    youtube_max_concurrent: int = 3
+    youtube_cookie_file: str | None = None
+    youtube_po_token: str | None = None
+    youtube_visitor_data: str | None = None
+    youtube_data_sync_id: str | None = None
+    youtube_impersonate: str | None = "chrome-120"
+    youtube_player_clients: list[str] = ["tv", "web", "mweb"]
+    js_runtime: str | None = "deno"
+
+    pinecone_index_name: str = "audiorag"
+    pinecone_namespace: str = "default"
+    weaviate_collection_name: str = "AudioRAG"
+    chromadb_persist_directory: str = "./chroma_db"
+    chromadb_collection_name: str = "audiorag"
+    supabase_collection_name: str = "audiorag"
+    supabase_vector_dimension: int = 1536
+
+    stt_model: str = "whisper-1"
+    stt_language: str | None = None
+    embedding_model: str = "text-embedding-3-small"
+    generation_model: str = "gpt-4o-mini"
+    reranker_model: str = "rerank-v3.5"
+
+    retrieval_top_k: int = 10
+    rerank_top_n: int = 3
+    cleanup_audio: bool = True
+
+    log_level: str = "INFO"
+    log_format: str = "colored"
+    log_timestamps: bool = True
+
+    retry_max_attempts: int = 3
+    retry_min_wait_seconds: float = 4.0
+    retry_max_wait_seconds: float = 60.0
+    retry_exponential_multiplier: float = 1.0
+
+    budget_enabled: bool = False
+    budget_rpm: int | None = None
+    budget_tpm: int | None = None
+    budget_audio_seconds_per_hour: int | None = None
+    budget_token_chars_per_token: int = 4
+    budget_provider_overrides: dict[str, dict[str, Any]] = Field(default_factory=dict)
+
+    vector_store_verify_mode: Literal["off", "best_effort", "strict"] = "best_effort"
+    vector_store_verify_max_attempts: int = 5
+    vector_store_verify_wait_seconds: float = 0.5
+    vector_id_format: Literal["auto", "sha256", "uuid5"] = "auto"
+    vector_id_uuid5_namespace: str | None = None
+
+    @field_validator("vector_id_uuid5_namespace")
+    @classmethod
+    def _validate_uuid_ns(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return str(uuid.UUID(v))
+
+    advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
+
+    @model_validator(mode="after")
+    def _sync_to_advanced(self) -> AudioRAGConfig:
+        for key in _ADVANCED_KEYS:
+            val = getattr(self, key, None)
+            setattr(self.advanced, key, val)
+        return self
+
     def get_stt_model(self) -> str:
-        """Get STT model based on provider."""
         provider = self.stt_provider.lower()
         if provider == "groq":
             return "whisper"
@@ -131,12 +206,10 @@ class AudioRAGConfig(BaseSettings):
             return "nova-2"
         if provider == "assemblyai":
             return "best"
-        return self.stt_model
+        return self.advanced.stt_model
 
     def get_embedding_model(self) -> str:
-        """Get embedding model based on provider."""
-        return self.embedding_model
+        return self.advanced.embedding_model
 
     def get_generation_model(self) -> str:
-        """Get generation model based on provider."""
-        return self.generation_model
+        return self.advanced.generation_model

--- a/src/audiorag/core/provider_factory.py
+++ b/src/audiorag/core/provider_factory.py
@@ -83,8 +83,13 @@ def create_vector_store_provider(
     provider_name = config.vector_store_provider.lower()
 
     if provider_name == "supabase":
-        from audiorag.store.supabase import SupabasePgVectorStore
-
+        try:
+            from audiorag.store.supabase import SupabasePgVectorStore
+        except ImportError as e:
+            raise ImportError(
+                "supabase vector store requires 'supabase' package. "
+                "Install with: pip install audiorag[supabase]"
+            ) from e
         return SupabasePgVectorStore(
             connection_string=config.supabase_connection_string or "",
             collection_name=config.supabase_collection_name or "audiorag",
@@ -92,8 +97,13 @@ def create_vector_store_provider(
             retry_config=retry_config,
         )
     if provider_name == "pinecone":
-        from audiorag.store.pinecone import PineconeVectorStore
-
+        try:
+            from audiorag.store.pinecone import PineconeVectorStore
+        except ImportError as e:
+            raise ImportError(
+                "pinecone vector store requires 'pinecone-client' package. "
+                "Install with: pip install audiorag[pinecone]"
+            ) from e
         return PineconeVectorStore(
             api_key=config.pinecone_api_key or "",
             index_name=config.pinecone_index_name or "audiorag",
@@ -101,16 +111,26 @@ def create_vector_store_provider(
             retry_config=retry_config,
         )
     if provider_name == "weaviate":
-        from audiorag.store.weaviate import WeaviateVectorStore
-
+        try:
+            from audiorag.store.weaviate import WeaviateVectorStore
+        except ImportError as e:
+            raise ImportError(
+                "weaviate vector store requires 'weaviate-client' package. "
+                "Install with: pip install audiorag[weaviate]"
+            ) from e
         return WeaviateVectorStore(
             url=config.weaviate_url or None,
             api_key=config.weaviate_api_key or None,
             collection_name=config.weaviate_collection_name or "AudioRAG",
             retry_config=retry_config,
         )
-    from audiorag.store.chromadb import ChromaDBVectorStore
-
+    try:
+        from audiorag.store.chromadb import ChromaDBVectorStore
+    except ImportError as e:
+        raise ImportError(
+            "chromadb vector store requires 'chromadb' package. "
+            "Install with: pip install audiorag[chromadb]"
+        ) from e
     return ChromaDBVectorStore(
         persist_directory=config.chromadb_persist_directory or "./chroma_db",
         collection_name=config.chromadb_collection_name or "audiorag",

--- a/src/audiorag/pipeline.py
+++ b/src/audiorag/pipeline.py
@@ -483,7 +483,6 @@ class AudioRAGPipeline:
                 Path(config.youtube_download_archive) if config.youtube_download_archive else None
             )
             self._audio_source = YouTubeSource(
-                retry_config=retry_config,
                 download_archive=archive_path,
                 concurrent_fragments=config.youtube_concurrent_fragments,
                 skip_playlist_after_errors=config.youtube_skip_after_errors,

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,6 @@ all = [
     { name = "groq" },
     { name = "openai" },
     { name = "pinecone-client" },
-    { name = "pydub" },
     { name = "supabase" },
     { name = "voyageai" },
     { name = "weaviate-client" },
@@ -247,7 +246,6 @@ deepgram = [
     { name = "deepgram-sdk" },
 ]
 defaults = [
-    { name = "pydub" },
     { name = "yt-dlp" },
 ]
 google-genai = [
@@ -276,7 +274,6 @@ weaviate = [
 ]
 youtube = [
     { name = "curl-cffi" },
-    { name = "pydub" },
     { name = "yt-dlp" },
     { name = "yt-dlp-ejs" },
 ]
@@ -318,9 +315,6 @@ requires-dist = [
     { name = "pinecone-client", marker = "extra == 'pinecone'", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
-    { name = "pydub", marker = "extra == 'all'", specifier = ">=0.25" },
-    { name = "pydub", marker = "extra == 'defaults'", specifier = ">=0.25" },
-    { name = "pydub", marker = "extra == 'youtube'", specifier = ">=0.25" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "structlog", specifier = ">=24.0" },
@@ -2707,15 +2701,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
-]
-
-[[package]]
-name = "pydub"
-version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace pydub with ffmpeg subprocess in AudioSplitter
- Remove Tenacity retry wrapper from YouTubeSource (yt-dlp has built-in)
- Add AdvancedConfig nested class for flattened config with AUDIORAG_ADVANCED_ prefix
- Add fail-fast ImportError with install hints for missing vector store packages
- Update docs to reflect pydub -> ffmpeg change

## Changes

- 10 files changed, +240/-169 lines
- Removed pydub dependency from defaults, all, and youtube extras
- Config now supports both flat (AUDIORAG_X) and nested (AUDIORAG_ADVANCED_X) env vars
- Vector stores fail fast with helpful install hints when packages are missing