### PR TITLE
fix(pipeline): re-raise BudgetExceededError in pre-download stage

### DIFF
--- a/src/audiorag/pipeline.py
+++ b/src/audiorag/pipeline.py
@@ -154,6 +154,8 @@ class DownloadStage(Stage):
                             audio_seconds=seconds,
                         )
                         ctx.reserved_audio_seconds = seconds
+                except BudgetExceededError:
+                    raise
                 except Exception as e:
                     ctx.logger.warning("pre_download_metadata_failed", error=str(e))
                     # Fallback to standard download if metadata fetch fails


### PR DESCRIPTION
## Summary

- Fixes issue #11: BudgetExceededError was being swallowed by generic `except Exception` block in `DownloadStage.execute()`
- Before: Budget errors during pre-download metadata extraction were caught, logged as a warning, and pipeline continued (wasting bandwidth + API calls)
- After: Budget errors are now properly re-raised and fail-fast at the pre-download stage

## Changes

- Added explicit `except BudgetExceededError: raise` before the generic `except Exception` handler in `DownloadStage.execute()`

## Testing

- All 454 tests pass
- Existing test `test_index_fails_fast_when_audio_budget_insufficient` verifies the fail-fast behavior