### PR TITLE
feat: add youtube_format config for audio-only downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ export AUDIORAG_YOUTUBE_PO_TOKEN="..."           # PO token for bot detection by
 export AUDIORAG_YOUTUBE_VISITOR_DATA="..."       # Visitor session (bound to PO token)
 export AUDIORAG_JS_RUNTIME="deno"                # JS runtime (deno/node/bun)
 
+# Optional YouTube audio-only download (saves ~95% bandwidth)
+export AUDIORAG_YOUTUBE_FORMAT="bestaudio"       # bestaudio | bestaudio/best | worstaudio
+
 # Optional budget governor
 export AUDIORAG_BUDGET_ENABLED="true"
 export AUDIORAG_BUDGET_RPM="60"

--- a/src/audiorag/core/config.py
+++ b/src/audiorag/core/config.py
@@ -89,6 +89,7 @@ class AdvancedConfig(BaseSettings):
     youtube_data_sync_id: str | None = None
     youtube_impersonate: str | None = "chrome-120"
     youtube_player_clients: list[str] = ["tv", "web", "mweb"]
+    youtube_format: str | None = None
     js_runtime: str | None = "deno"
 
     pinecone_index_name: str = "audiorag"
@@ -213,6 +214,7 @@ class AudioRAGConfig(BaseSettings):
     youtube_data_sync_id: str | None = None
     youtube_impersonate: str | None = "chrome-120"
     youtube_player_clients: list[str] = ["tv", "web", "mweb"]
+    youtube_format: str | None = None
     js_runtime: str | None = "deno"
 
     pinecone_index_name: str = "audiorag"

--- a/src/audiorag/source/ydl_utils.py
+++ b/src/audiorag/source/ydl_utils.py
@@ -81,4 +81,7 @@ def build_ydl_opts(config: AudioRAGConfig) -> dict[str, Any] | None:
 
         ydl_opts["impersonate"] = ImpersonateTarget.from_str(config.youtube_impersonate)
 
+    if config.youtube_format:
+        ydl_opts["format"] = config.youtube_format
+
     return ydl_opts if ydl_opts else None

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -343,6 +343,26 @@ class TestBuildYdlOpts:
         assert result is not None
         assert result["extractor_args"]["youtube"]["visitor_data"] == "test_visitor_data"
 
+    def test_youtube_format(self) -> None:
+        """Test youtube format option for audio-only downloads."""
+        from audiorag.core.config import AudioRAGConfig
+        from audiorag.source.ydl_utils import build_ydl_opts
+
+        config = AudioRAGConfig(youtube_format="bestaudio")
+        result = build_ydl_opts(config)
+        assert result is not None
+        assert result["format"] == "bestaudio"
+
+    def test_youtube_format_with_fallback(self) -> None:
+        """Test youtube format with fallback option."""
+        from audiorag.core.config import AudioRAGConfig
+        from audiorag.source.ydl_utils import build_ydl_opts
+
+        config = AudioRAGConfig(youtube_format="bestaudio/best")
+        result = build_ydl_opts(config)
+        assert result is not None
+        assert result["format"] == "bestaudio/best"
+
     def test_multiple_options(self) -> None:
         """Test multiple options combined."""
         from audiorag.core.config import AudioRAGConfig


### PR DESCRIPTION
## Summary

Add `youtube_format` config option to enable audio-only YouTube downloads, reducing bandwidth by ~95% (e.g., 680MB → 25MB for a 28-minute video).

## Changes

- Added `youtube_format` config option in `AudioRAGConfig` and `AdvancedConfig`
- Updated `build_ydl_opts()` to pass format selection to yt-dlp
- Added tests for the new option
- Updated README with documentation

## Usage

```bash
export AUDIORAG_YOUTUBE_FORMAT=bestaudio
```

Options: `bestaudio`, `bestaudio/best`, `worstaudio`

Closes #39