### PR TITLE
fix: youtube discovery fixes for issues #41 and #43

### DIFF
--- a/src/audiorag/source/youtube.py
+++ b/src/audiorag/source/youtube.py
@@ -60,7 +60,8 @@ class YouTubeSource:
             self._download_archive.parent.mkdir(parents=True, exist_ok=True)
             opts["download_archive"] = str(self._download_archive)
 
-        opts.update(self._ydl_opts)
+        if not metadata_only:
+            opts.update(self._ydl_opts)
 
         if metadata_only:
             opts["skip_download"] = True

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -240,9 +240,12 @@ class TestPipelineIndex:
             "https://youtube.com/watch?v=video1",
             "https://youtube.com/watch?v=video2",
         ]
+        from audiorag.source.discovery import DiscoveredSource
+
+        discovered = [DiscoveredSource(url=u) for u in expanded_sources]
         discover_mock = mocker.patch(
             "audiorag.pipeline.discover_sources",
-            new=AsyncMock(return_value=expanded_sources),
+            new=AsyncMock(return_value=discovered),
         )
 
         await pipeline_for_index.index(playlist_url)
@@ -261,9 +264,12 @@ class TestPipelineIndex:
             "https://youtube.com/watch?v=video1",
             "https://youtube.com/watch?v=video2",
         ]
+        from audiorag.source.discovery import DiscoveredSource
+
+        discovered = [DiscoveredSource(url=u) for u in expanded_sources]
         mocker.patch(
             "audiorag.pipeline.discover_sources",
-            new=AsyncMock(return_value=expanded_sources),
+            new=AsyncMock(return_value=discovered),
         )
 
         await pipeline_for_index.index_many(inputs)
@@ -280,9 +286,12 @@ class TestPipelineIndex:
             "https://youtube.com/watch?v=video1",
             "https://youtube.com/watch?v=video2",
         ]
+        from audiorag.source.discovery import DiscoveredSource
+
+        discovered = [DiscoveredSource(url=u) for u in expanded_sources]
         mocker.patch(
             "audiorag.pipeline.discover_sources",
-            new=AsyncMock(return_value=expanded_sources),
+            new=AsyncMock(return_value=discovered),
         )
 
         result = await pipeline_for_index.index_many(inputs, raise_on_error=False)
@@ -305,9 +314,12 @@ class TestPipelineIndex:
             "https://youtube.com/watch?v=video2",
             "https://youtube.com/watch?v=video3",
         ]
+        from audiorag.source.discovery import DiscoveredSource
+
+        discovered = [DiscoveredSource(url=u) for u in expanded_sources]
         mocker.patch(
             "audiorag.pipeline.discover_sources",
-            new=AsyncMock(return_value=expanded_sources),
+            new=AsyncMock(return_value=discovered),
         )
 
         default_audio_file = pipeline_for_index._audio_source.download.return_value
@@ -352,17 +364,20 @@ class TestPipelineIndex:
             "https://youtube.com/watch?v=video2",
             "https://youtube.com/watch?v=video3",
         ]
+        from audiorag.source.discovery import DiscoveredSource
+
+        discovered = [DiscoveredSource(url=u) for u in expanded_sources]
         mocker.patch(
             "audiorag.pipeline.discover_sources",
-            new=AsyncMock(return_value=expanded_sources),
+            new=AsyncMock(return_value=discovered),
         )
 
         original_index_single = pipeline_for_index._index_single_source
 
-        async def failing_index_single(url: str, *, force: bool = False):
+        async def failing_index_single(url: str, *, force: bool = False, **kwargs):
             if url.endswith("video2"):
                 raise RuntimeError("unexpected crash")
-            return await original_index_single(url, force=force)
+            return await original_index_single(url, force=force, **kwargs)
 
         mocker.patch.object(
             pipeline_for_index,


### PR DESCRIPTION
## Summary

- **Fix #43**: Skip yt-dlp options during metadata-only extraction to prevent `youtube_format` from causing errors during playlist discovery
- **Fix #41**: Cache metadata during discovery and pass to pipeline to avoid redundant yt-dlp calls when indexing each video

## Changes

### Issue #43 (youtube_format during discovery)
- Modified `_get_opts()` in `youtube.py` to only apply `ydl_opts` when `metadata_only=False`
- This prevents format errors when discovering playlists with `youtube_format` config set

### Issue #41 (Redundant discovery calls)
- Added `DiscoveredSource` dataclass with `url` and `metadata` fields
- Modified `discover_sources()` to return `list[DiscoveredSource]` with cached metadata
- Updated `index_many()` to pass cached metadata to pipeline stages
- Updated `DownloadStage._pre_download_budget_check()` to use cached metadata when available
- Added `discover_source_urls()` convenience function for backward compatibility

## Testing

- All 560 tests pass
- Added explicit tests for Issue #43 fix behavior
- Updated existing tests to work with new return types

Closes #41
Closes #43