### PR TITLE
fix: narrow youtube_format exclusion to format key only

### DIFF
--- a/src/audiorag/source/youtube.py
+++ b/src/audiorag/source/youtube.py
@@ -60,8 +60,12 @@ class YouTubeSource:
             self._download_archive.parent.mkdir(parents=True, exist_ok=True)
             opts["download_archive"] = str(self._download_archive)
 
-        if not metadata_only:
-            opts.update(self._ydl_opts)
+        # Apply ydl_opts, but skip format during metadata-only extraction
+        # to avoid "Requested format is not available" errors (Issue #43)
+        for key, value in self._ydl_opts.items():
+            if metadata_only and key == "format":
+                continue
+            opts[key] = value
 
         if metadata_only:
             opts["skip_download"] = True

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -168,18 +168,23 @@ class TestExpandYouTubeSource:
 class TestYouTubeSourceYdlOpts:
     """Test YouTubeSource ydl_opts handling."""
 
-    def test_ydl_opts_not_applied_during_metadata_only(self) -> None:
-        """Test ydl_opts are NOT applied during metadata-only extraction (Issue #43)."""
+    def test_format_excluded_during_metadata_only(self) -> None:
+        """Test format option is excluded during metadata-only extraction (Issue #43)."""
         from audiorag.source.youtube import YouTubeSource
 
+        # The issue is triggered by youtube_format config which sets the format option
         source = YouTubeSource(
-            ydl_opts={"extractor_args": {"youtube": {"player_client": ["tv", "android"]}}}
+            ydl_opts={
+                "format": "bestaudio",  # This should be excluded during metadata-only
+                "extractor_args": {"youtube": {"player_client": ["tv", "android"]}},
+            }
         )
         opts = source._get_opts(metadata_only=True)
 
-        # ydl_opts should NOT be applied during metadata-only extraction
-        # to avoid format errors during playlist discovery
-        assert "extractor_args" not in opts
+        # Format should be excluded to avoid "Requested format is not available" errors
+        assert "format" not in opts
+        # But other options like extractor_args should still be applied
+        assert opts["extractor_args"]["youtube"]["player_client"] == ["tv", "android"]
         assert opts["skip_download"] is True
 
     def test_ydl_opts_applied_during_download(self) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #44 based on Copilot review feedback.

- **Narrows Issue #43 fix**: Instead of skipping all `ydl_opts` during metadata-only extraction, only exclude the `format` key. This preserves auth/session options (cookies, po_token, visitor_data, extractor_args) needed for age-restricted/private content discovery.
- **Updated test**: Now specifically tests that `format` is excluded while `extractor_args` are preserved during metadata-only extraction.

## Why

The original fix skipped all `ydl_opts` during `metadata_only=True`, which would break playlist discovery for age-restricted or private content requiring authentication options.